### PR TITLE
Pagetable

### DIFF
--- a/include/host.h
+++ b/include/host.h
@@ -9,7 +9,8 @@ typedef struct cdt_server_t cdt_server_t;
 #define CDT_MAX_SHARED_PAGES 1024 // note: we may want to change this 
 
 
-/* Pagetable entry for a single page in a machine's page table (NOT the manager). */
+/* Pagetable entry for a single page in a machine's page table (NOT the manager). 
+   The PTE must be locked before being accessed in any way. */
 typedef struct cdt_host_pte_t {
   int in_use;
   uint64_t shared_va;
@@ -17,6 +18,7 @@ typedef struct cdt_host_pte_t {
   int access;
   /* if access = INVALID then page = NULL */
   void * page;
+  pthread_mutex_t lock;
 } cdt_host_pte_t;
 
 /* Pagetable entry for a single page in the manager's page table. 

--- a/include/host.h
+++ b/include/host.h
@@ -7,6 +7,9 @@ typedef struct cdt_server_t cdt_server_t;
 
 #define CDT_MAX_MACHINES 32
 #define CDT_MAX_SHARED_PAGES 1024 // note: we may want to change this 
+#define INVALID_PAGE 0
+#define READ_ONLY_PAGE 1
+#define READ_WRITE_PAGE 2
 
 
 /* Pagetable entry for a single page in a machine's page table (NOT the manager). 

--- a/include/host.h
+++ b/include/host.h
@@ -11,6 +11,7 @@ typedef struct cdt_server_t cdt_server_t;
 
 /* Pagetable entry for a single page in a machine's page table (NOT the manager). */
 typedef struct cdt_host_pte_t {
+  int in_use;
   uint64_t shared_va;
   /* access is one of READ_ONLY, READ_WRITE, and INVALID */
   int access;
@@ -21,6 +22,7 @@ typedef struct cdt_host_pte_t {
 /* Pagetable entry for a single page in the manager's page table. 
    The PTE must be locked before being accessed in any way. */
 typedef struct cdt_manager_pte_t {
+  int in_use;
   uint64_t shared_va; 
   /* The set of machines that have read access. 
      Each entry is 0 or 1 indicating no access or read access */
@@ -30,7 +32,7 @@ typedef struct cdt_manager_pte_t {
   int writer;
   /* Pointer to the page itself */
   void * page;
-  pthread_mutex_t * lock;
+  pthread_mutex_t lock;
 } cdt_manager_pte_t;
 
 typedef struct cdt_host_t {

--- a/include/host.h
+++ b/include/host.h
@@ -6,6 +6,32 @@
 typedef struct cdt_server_t cdt_server_t;
 
 #define CDT_MAX_MACHINES 32
+#define CDT_MAX_SHARED_PAGES 1024 // note: we may want to change this 
+
+
+/* Pagetable entry for a single page in a machine's page table (NOT the manager). */
+typedef struct cdt_host_pte_t {
+  uint64_t shared_va;
+  /* access is one of READ_ONLY, READ_WRITE, and INVALID */
+  int access;
+  /* if access = INVALID then page = NULL */
+  void * page;
+} cdt_host_pte_t;
+
+/* Pagetable entry for a single page in the manager's page table. 
+   The PTE must be locked before being accessed in any way. */
+typedef struct cdt_manager_pte_t {
+  uint64_t shared_va; 
+  /* The set of machines that have read access. 
+     Each entry is 0 or 1 indicating no access or read access */
+  int read_set[CDT_MAX_MACHINES]; 
+  /* The machine ID with R/W access. If this is -1, there is no writer. 
+     If this is >=0 then read_set must be all zeros */
+  int writer;
+  /* Pointer to the page itself */
+  void * page;
+  pthread_mutex_t * lock;
+} cdt_manager_pte_t;
 
 typedef struct cdt_host_t {
   /* Will be 1 if this machine is the manager, otherwise 0. */
@@ -19,6 +45,9 @@ typedef struct cdt_host_t {
   /* Each bit represents whether a peer is waiting to be connected. */
   int peers_to_be_connected;
   cdt_peer_t peers[CDT_MAX_MACHINES];
+  cdt_host_pte_t shared_pagetable[CDT_MAX_SHARED_PAGES];
+  /* This array is only valid if the host is the manager. */
+  cdt_manager_pte_t manager_pagetable[CDT_MAX_SHARED_PAGES];
 } cdt_host_t;
 
 /**

--- a/src/host.c
+++ b/src/host.c
@@ -10,6 +10,16 @@ void* cdt_host_thread(void *arg) {
 
   printf("Server started\n");
 
+  // Initialize all the locks for manager pagetable.
+  if (host->manager) {
+    for (int i = 0; i < CDT_MAX_SHARED_PAGES; i++) {
+      if (pthread_mutex_init(&host->manager_pagetable[i].lock, NULL) != 0) { 
+        fprintf(stderr, "Failed to init lock for manager PTE index %d\n", i);
+        return NULL;
+      } 
+    }
+  }
+
   host->num_peers = host->manager ? 1 : 2;
 
   cdt_connection_t connection;

--- a/src/host.c
+++ b/src/host.c
@@ -10,10 +10,17 @@ void* cdt_host_thread(void *arg) {
 
   printf("Server started\n");
 
-  // Initialize all the locks for manager pagetable.
+  // Initialize all the locks for appropriate pagetable.
   if (host->manager) {
     for (int i = 0; i < CDT_MAX_SHARED_PAGES; i++) {
       if (pthread_mutex_init(&host->manager_pagetable[i].lock, NULL) != 0) { 
+        fprintf(stderr, "Failed to init lock for manager PTE index %d\n", i);
+        return NULL;
+      } 
+    }
+  } else {
+    for (int i = 0; i < CDT_MAX_SHARED_PAGES; i++) {
+      if (pthread_mutex_init(&host->shared_pagetable[i].lock, NULL) != 0) { 
         fprintf(stderr, "Failed to init lock for manager PTE index %d\n", i);
         return NULL;
       } 


### PR DESCRIPTION
Add a struct for host PTEs and manager PTEs. Each PTE for both manager page tables and host page tables has a lock. Locks are initialized in host.c, and all other fields of the PTE are default initialized to zero.

Each host statically allocates an array of PTEs with a size of CDT_MAX_SHARED_PAGES. This is pretty wasteful and we do want to look into making this dynamically allocated, but it does allow fast lookup if a shared virtual address is mapped to a fixed index.