### PR TITLE
Allocation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ SDIR = src
 ODIR = bin
 
 CC = gcc
-CFLAGS = -Wall -Werror -I$(IDIR) -lpthread -lm -lrt -D DEBUG=1 -Wno-unused-command-line-argument 
+CFLAGS = -Wall -Werror -I$(IDIR) -lpthread -lrt -D DEBUG=1 -Wno-unused-command-line-argument 
 
 DEPS := $(wildcard $(IDIR)/*.h)
 OBJS := $(patsubst $(SDIR)/%.c,$(ODIR)/%.o,$(wildcard $(SDIR)/*.c))

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ SDIR = src
 ODIR = bin
 
 CC = gcc
-CFLAGS = -Wall -Werror -I$(IDIR) -lpthread -D DEBUG=1 -Wno-unused-command-line-argument
+CFLAGS = -Wall -Werror -I$(IDIR) -lpthread -D DEBUG=1 -Wno-unused-command-line-argument -lm
 
 DEPS := $(wildcard $(IDIR)/*.h)
 OBJS := $(patsubst $(SDIR)/%.c,$(ODIR)/%.o,$(wildcard $(SDIR)/*.c))

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ SDIR = src
 ODIR = bin
 
 CC = gcc
-CFLAGS = -Wall -Werror -I$(IDIR) -lpthread -D DEBUG=1 -Wno-unused-command-line-argument -lm
+CFLAGS = -Wall -Werror -I$(IDIR) -lpthread -lm -lrt -D DEBUG=1 -Wno-unused-command-line-argument 
 
 DEPS := $(wildcard $(IDIR)/*.h)
 OBJS := $(patsubst $(SDIR)/%.c,$(ODIR)/%.o,$(wildcard $(SDIR)/*.c))

--- a/include/coordinate.h
+++ b/include/coordinate.h
@@ -2,6 +2,9 @@
 #define COORDINATE_H
 
 #include <stddef.h>
+#include "packet.h"
+#include "host.h"
+#include <stdio.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/coordinate.h
+++ b/include/coordinate.h
@@ -4,6 +4,7 @@
 #include <stddef.h>
 #include "packet.h"
 #include "host.h"
+#include "message.h"
 #include <stdio.h>
 
 #ifdef __cplusplus

--- a/include/host.h
+++ b/include/host.h
@@ -40,7 +40,7 @@ typedef struct cdt_manager_pte_t {
   /* The machine ID with R/W access. If this is -1, there is no writer. 
      If this is >=0 then read_set must be all zeros */
   int writer;
-  /* Pointer to the page itself which is only valid when the pag eis in R/O mode */
+  /* Pointer to the page itself which is only valid when the page is in R/O mode */
   void * page;
   pthread_mutex_t lock;
 } cdt_manager_pte_t;

--- a/include/host.h
+++ b/include/host.h
@@ -12,7 +12,8 @@ typedef struct cdt_server_t cdt_server_t;
 #define INVALID_PAGE 0
 #define READ_ONLY_PAGE 1
 #define READ_WRITE_PAGE 2
-
+#define SHARED_VA_TO_IDX(va) ((va - CDT_SHARED_VA_START) / PAGESIZE)
+#define PGROUNDDOWN(a) (((a)) & ~(PAGESIZE-1))
 
 /* Pagetable entry for a single page in a machine's page table (NOT the manager). 
    The PTE must be locked before being accessed in any way. */

--- a/include/host.h
+++ b/include/host.h
@@ -8,7 +8,7 @@ typedef struct cdt_server_t cdt_server_t;
 #define CDT_MAX_MACHINES 32
 #define CDT_MAX_SHARED_PAGES 1024 // note: we may want to change this 
 #define CDT_SHARED_VA_START (1L << 32)
-#define CDT_SHARED_VA_END ((1L << 32) + CDT_MAX_SHARED_PAGES)
+#define CDT_SHARED_VA_END ((1L << 32) + CDT_MAX_SHARED_PAGES * getpagesize())
 #define INVALID_PAGE 0
 #define READ_ONLY_PAGE 1
 #define READ_WRITE_PAGE 2
@@ -18,6 +18,7 @@ typedef struct cdt_server_t cdt_server_t;
    The PTE must be locked before being accessed in any way. */
 typedef struct cdt_host_pte_t {
   int in_use;
+  /* shared_va should never be changed after init */
   uint64_t shared_va;
   /* access is one of READ_ONLY, READ_WRITE, and INVALID */
   int access;
@@ -30,6 +31,7 @@ typedef struct cdt_host_pte_t {
    The PTE must be locked before being accessed in any way. */
 typedef struct cdt_manager_pte_t {
   int in_use;
+  /* shared_va should never be changed after init */
   uint64_t shared_va; 
   /* The set of machines that have read access. 
      Each entry is 0 or 1 indicating no access or read access */

--- a/include/host.h
+++ b/include/host.h
@@ -8,7 +8,7 @@ typedef struct cdt_server_t cdt_server_t;
 #define CDT_MAX_MACHINES 32
 #define CDT_MAX_SHARED_PAGES 1024 // note: we may want to change this 
 #define CDT_SHARED_VA_START (1L << 32)
-#define CDT_SHARED_VA_END ((1L << 32) + CDT_MAX_SHARED_PAGES * getpagesize())
+#define CDT_SHARED_VA_END ((1L << 32) + CDT_MAX_SHARED_PAGES * PAGESIZE)
 #define INVALID_PAGE 0
 #define READ_ONLY_PAGE 1
 #define READ_WRITE_PAGE 2

--- a/include/host.h
+++ b/include/host.h
@@ -7,6 +7,8 @@ typedef struct cdt_server_t cdt_server_t;
 
 #define CDT_MAX_MACHINES 32
 #define CDT_MAX_SHARED_PAGES 1024 // note: we may want to change this 
+#define CDT_SHARED_VA_START (1L << 32)
+#define CDT_SHARED_VA_END ((1L << 32) + CDT_MAX_SHARED_PAGES)
 #define INVALID_PAGE 0
 #define READ_ONLY_PAGE 1
 #define READ_WRITE_PAGE 2

--- a/include/host.h
+++ b/include/host.h
@@ -35,7 +35,7 @@ typedef struct cdt_manager_pte_t {
   /* The machine ID with R/W access. If this is -1, there is no writer. 
      If this is >=0 then read_set must be all zeros */
   int writer;
-  /* Pointer to the page itself */
+  /* Pointer to the page itself which is only valid when the pag eis in R/O mode */
   void * page;
   pthread_mutex_t lock;
 } cdt_manager_pte_t;

--- a/include/message.h
+++ b/include/message.h
@@ -1,3 +1,6 @@
+#ifndef COORDINATE_MESSAGE_H
+#define COORDINATE_MESSAGE_H
+
 #include "util.h"
 #include <stdint.h>
 
@@ -17,3 +20,5 @@ typedef struct cdt_message_t {
   uint64_t shared_va;
   char page[PAGESIZE + 1];
 } cdt_message_t;
+
+#endif

--- a/include/message.h
+++ b/include/message.h
@@ -1,0 +1,19 @@
+#include "util.h"
+#include <stdint.h>
+
+#define MAIN_MANAGER_QUEUE_NAME   "/managerPeerToMainThread"
+#define QUEUE_PERMISSIONS 0660
+#define MAX_MESSAGES 10 // this is a limit enforced by mqueue (see mq_overview man page)
+#define MSG_SIZE sizeof(cdt_message_t)
+
+// Message types
+#define ALLOCATE_RESP 0
+
+/**
+ * The type for messages passed between threads using a message queue.
+ */
+typedef struct cdt_message_t {
+  int type;
+  uint64_t shared_va;
+  char page[PAGESIZE + 1];
+} cdt_message_t;

--- a/include/packet.h
+++ b/include/packet.h
@@ -11,6 +11,9 @@ enum cdt_packet_type {
   CDT_PACKET_NEW_PEER,
   CDT_PACKET_EXISTING_PEER,
 
+  CDT_PACKET_ALLOC_REQ,
+  CDT_PACKET_ALLOC_RESP,
+
   CDT_PACKET_READ_REQ,
   CDT_PACKET_READ_RESP,
   CDT_PACKET_READ_INVALIDATE_REQ,
@@ -49,6 +52,12 @@ int cdt_packet_new_peer_parse(cdt_packet_t *packet, int *peer_id, char **address
 
 int cdt_packet_existing_peer_create(cdt_packet_t *packet, int peer_id);
 int cdt_packet_existing_peer_parse(cdt_packet_t *packet, int *peer_id);
+
+int cdt_packet_alloc_req_create(cdt_packet_t *packet, int peer_id);
+int cdt_packet_alloc_req_parse(cdt_packet_t *packet, int *peer_id);
+
+int cdt_packet_alloc_resp_create(cdt_packet_t *packet, void* page);
+int cdt_packet_alloc_resp_parse(cdt_packet_t *packet, void * page);
 
 int cdt_packet_read_req_create(cdt_packet_t *packet, unsigned long page_addr);
 int cdt_packet_read_req_parse(cdt_packet_t *packet, unsigned long *page_addr);

--- a/include/packet.h
+++ b/include/packet.h
@@ -2,6 +2,7 @@
 #define COORDINATE_PACKET_H
 
 #define CDT_PACKET_DATA_SIZE 100
+#include <stdint.h>
 
 enum cdt_packet_type {
   CDT_PACKET_SELF_IDENTIFY,
@@ -56,8 +57,8 @@ int cdt_packet_existing_peer_parse(cdt_packet_t *packet, int *peer_id);
 int cdt_packet_alloc_req_create(cdt_packet_t *packet, int peer_id);
 int cdt_packet_alloc_req_parse(cdt_packet_t *packet, int *peer_id);
 
-int cdt_packet_alloc_resp_create(cdt_packet_t *packet, void* page);
-int cdt_packet_alloc_resp_parse(cdt_packet_t *packet, void * page);
+int cdt_packet_alloc_resp_create(cdt_packet_t *packet, uint64_t page);
+int cdt_packet_alloc_resp_parse(cdt_packet_t *packet, uint64_t * page);
 
 int cdt_packet_read_req_create(cdt_packet_t *packet, unsigned long page_addr);
 int cdt_packet_read_req_parse(cdt_packet_t *packet, unsigned long *page_addr);

--- a/include/packet.h
+++ b/include/packet.h
@@ -1,8 +1,10 @@
+#include <stdint.h>
+#include "util.h"
+
 #ifndef COORDINATE_PACKET_H
 #define COORDINATE_PACKET_H
-
-#define CDT_PACKET_DATA_SIZE 100
-#include <stdint.h>
+// Page size for when we need to send pages +1 for null terminating character?
+#define CDT_PACKET_DATA_SIZE (PAGESIZE + 1) 
 
 enum cdt_packet_type {
   CDT_PACKET_SELF_IDENTIFY,

--- a/include/peer.h
+++ b/include/peer.h
@@ -5,6 +5,7 @@
 #include "connection.h"
 
 typedef struct cdt_host_t cdt_host_t;
+typedef struct cdt_manager_pte_t cdt_manager_pte_t;
 
 /**
  * Represents a peer machine in the network.
@@ -27,5 +28,7 @@ int cdt_peer_start(cdt_peer_t *peer);
  * Wait for the peer reading thred to finish.
  */
 void cdt_peer_join(cdt_peer_t *peer);
+
+int cdt_find_unused_pte(cdt_manager_pte_t ** fresh_pte, int peer_id) ;
 
 #endif

--- a/include/util.h
+++ b/include/util.h
@@ -1,5 +1,6 @@
 #ifndef COORDINATE_UTIL_H
 #define COORDINATE_UTIL_H
+#define PAGESIZE 4096
 
 #include <stdio.h>
 

--- a/include/util.h
+++ b/include/util.h
@@ -8,3 +8,6 @@
                                 __LINE__, __func__, ##__VA_ARGS__); } while (0)
 
 #endif
+
+uint64_t htonll(uint64_t x);
+uint64_t ntohll(uint64_t x);

--- a/src/coordinate.c
+++ b/src/coordinate.c
@@ -1,7 +1,24 @@
 #include "coordinate.h"
 
+extern cdt_host_t host;
+extern cdt_connection_t manager_connection;
+
 void* cdt_malloc(size_t size) {
-  // TODO
+  if (host.manager) {
+    // Make the allocation
+    printf("Manager trying to malloc\n");
+
+  }
+  // Not the manager, so send msg to manager requesting allocation
+  cdt_packet_t packet;
+  if (cdt_packet_alloc_req_create(&packet, host.self_id) != 0) {
+    fprintf(stderr, "Cannot create allocation request packet\n");
+    return NULL;
+  }
+  if (cdt_connection_send(&manager_connection, &packet) != 0) {
+    fprintf(stderr, "Failed to send self identify packet\n");
+    return NULL;
+  }
   return NULL;
 }
 

--- a/src/coordinate.c
+++ b/src/coordinate.c
@@ -1,12 +1,16 @@
+#include <mqueue.h>
 #include "coordinate.h"
+#include "message.h"
 
 extern cdt_host_t host;
 extern cdt_connection_t manager_connection;
+extern mqd_t qd_manager_peer_thread;
 
 void* cdt_malloc(size_t size) {
   if (host.manager) {
     // Make the allocation
     printf("Manager trying to malloc\n");
+    return NULL;
 
   }
   // Not the manager, so send msg to manager requesting allocation
@@ -16,9 +20,20 @@ void* cdt_malloc(size_t size) {
     return NULL;
   }
   if (cdt_connection_send(&manager_connection, &packet) != 0) {
-    fprintf(stderr, "Failed to send self identify packet\n");
+    fprintf(stderr, "Failed to send allocation request packet\n");
     return NULL;
   }
+
+  cdt_message_t allocation_response;
+
+  if (mq_receive (qd_manager_peer_thread, (char *)&allocation_response, sizeof(allocation_response), NULL) == -1) {
+    debug_print("Failed to receive a message from manager peer-thread\n");
+    return NULL;
+  }
+
+  printf("Received message from manager peer-thread with type %d and shared VA %p\n", 
+    allocation_response.type, (void *)allocation_response.shared_va);
+
   return NULL;
 }
 

--- a/src/host.c
+++ b/src/host.c
@@ -1,5 +1,6 @@
 #include <stdio.h>
 #include <string.h>
+#include <unistd.h>
 #include "server.h"
 #include "connection.h"
 #include "packet.h"
@@ -10,13 +11,14 @@ void* cdt_host_thread(void *arg) {
 
   printf("Server started\n");
 
-  // Initialize all the locks for appropriate pagetable.
+  // Initialize all the locks and virtual addresses for appropriate pagetable
   if (host->manager) {
     for (int i = 0; i < CDT_MAX_SHARED_PAGES; i++) {
       if (pthread_mutex_init(&host->manager_pagetable[i].lock, NULL) != 0) { 
         fprintf(stderr, "Failed to init lock for manager PTE index %d\n", i);
         return NULL;
       } 
+      host->manager_pagetable[i].shared_va = i * getpagesize() + CDT_SHARED_VA_START;
     }
   } else {
     for (int i = 0; i < CDT_MAX_SHARED_PAGES; i++) {
@@ -24,6 +26,7 @@ void* cdt_host_thread(void *arg) {
         fprintf(stderr, "Failed to init lock for manager PTE index %d\n", i);
         return NULL;
       } 
+      host->shared_pagetable[i].shared_va = i * getpagesize() + CDT_SHARED_VA_START;
     }
   }
 

--- a/src/host.c
+++ b/src/host.c
@@ -18,7 +18,7 @@ void* cdt_host_thread(void *arg) {
         fprintf(stderr, "Failed to init lock for manager PTE index %d\n", i);
         return NULL;
       } 
-      host->manager_pagetable[i].shared_va = i * getpagesize() + CDT_SHARED_VA_START;
+      host->manager_pagetable[i].shared_va = i * PAGESIZE + CDT_SHARED_VA_START;
     }
   } else {
     for (int i = 0; i < CDT_MAX_SHARED_PAGES; i++) {
@@ -26,7 +26,7 @@ void* cdt_host_thread(void *arg) {
         fprintf(stderr, "Failed to init lock for manager PTE index %d\n", i);
         return NULL;
       } 
-      host->shared_pagetable[i].shared_va = i * getpagesize() + CDT_SHARED_VA_START;
+      host->shared_pagetable[i].shared_va = i * PAGESIZE + CDT_SHARED_VA_START;
     }
   }
 

--- a/src/main.c
+++ b/src/main.c
@@ -5,6 +5,10 @@
 #include "connection.h"
 #include "packet.h"
 #include "host.h"
+#include "coordinate.h"
+
+cdt_host_t host;
+cdt_connection_t manager_connection;
 
 int main(int argc, char *argv[]) {
   if (argc < 2) {
@@ -69,15 +73,12 @@ int main(int argc, char *argv[]) {
 
   printf("Listening at %s:%s\n", host_address == NULL ? "*" : host_address, host_port);
 
-  cdt_host_t host;
   memset(&host, 0, sizeof(host));
   host.manager = connection_index == 0;
   host.server = &server;
   host.peers_to_be_connected = ~1;
 
   if (connection_index) {
-    cdt_connection_t manager_connection;
-
     if (cdt_connection_connect(&manager_connection, connection_address, connection_port) == -1) {
       fprintf(stderr, "Error connecting to server\n");
       return -1;

--- a/src/main.c
+++ b/src/main.c
@@ -7,7 +7,6 @@
 #include "connection.h"
 #include "packet.h"
 #include "host.h"
-#include "coordinate.h"
 #include "message.h"
 
 cdt_host_t host;
@@ -137,9 +136,6 @@ int main(int argc, char *argv[]) {
     fprintf(stderr, "Cannot start host thread\n");
     return -1;
   }
-  // For testing
-  // printf("Mallocing\n");
-  // cdt_malloc(1);
 
   cdt_host_join(&host);
 

--- a/src/packet.c
+++ b/src/packet.c
@@ -89,3 +89,19 @@ int cdt_packet_existing_peer_parse(cdt_packet_t *packet, int *peer_id) {
 
   return 0;
 }
+
+int cdt_packet_alloc_req_create(cdt_packet_t *packet, int peer_id) {
+  packet->type = CDT_PACKET_ALLOC_REQ;
+  packet->size = sizeof(int);
+  *(int*)packet->data = htonl(peer_id);
+
+  return 0;
+}
+
+int cdt_packet_alloc_req_parse(cdt_packet_t *packet, int *peer_id) {
+  assert(packet->type == CDT_PACKET_ALLOC_REQ);
+
+  *peer_id = ntohl(*(int*)packet->data);
+
+  return 0;
+}

--- a/src/packet.c
+++ b/src/packet.c
@@ -2,6 +2,7 @@
 #include <string.h>
 #include <arpa/inet.h>
 #include "packet.h"
+#include "util.h"
 
 int cdt_packet_self_identify_create(cdt_packet_t *packet, const char *address, const char *port) {
   int address_len = strlen(address) + 1; // + 1 to include null terminating character
@@ -102,6 +103,22 @@ int cdt_packet_alloc_req_parse(cdt_packet_t *packet, int *peer_id) {
   assert(packet->type == CDT_PACKET_ALLOC_REQ);
 
   *peer_id = ntohl(*(int*)packet->data);
+
+  return 0;
+}
+
+int cdt_packet_alloc_resp_create(cdt_packet_t *packet, uint64_t page) {
+  packet->type = CDT_PACKET_ALLOC_RESP;
+  packet->size = sizeof(uint64_t);
+  *(uint64_t*)packet->data = htonll(page);
+
+  return 0;
+}
+
+int cdt_packet_alloc_resp_parse(cdt_packet_t *packet, uint64_t *page) {
+  assert(packet->type == CDT_PACKET_ALLOC_RESP);
+
+  *page = ntohll(*(uint64_t*)packet->data);
 
   return 0;
 }

--- a/src/peer.c
+++ b/src/peer.c
@@ -1,6 +1,5 @@
 #include <stdio.h>
 #include <stdint.h>
-#include <math.h>
 #include <assert.h>
 #include <string.h>
 #include <mqueue.h>

--- a/src/peer.c
+++ b/src/peer.c
@@ -57,7 +57,7 @@ int cdt_allocate_shared_page(int peer_id) {
       return -1;
     }
   }
-  printf("Found empty PTE with index %d\n", i);
+  printf("Found empty PTE with index %d and VA %p\n", i, (void *)fresh_pte->shared_va);
 
   // If we've gotten to this point, assume we're holding fresh_pte's lock
   fresh_pte->in_use = 1;

--- a/src/peer.c
+++ b/src/peer.c
@@ -3,6 +3,8 @@
 #include "packet.h"
 #include "host.h"
 
+extern cdt_host_t host;
+
 int cdt_peer_greet_existing_peer(cdt_host_t *host, int peer_id, const char *peer_address, const char *peer_port) {
   cdt_peer_t *peer = &host->peers[peer_id];
 
@@ -56,6 +58,16 @@ void* cdt_peer_thread(void *arg) {
       }
 
       printf("Greeted new peer %d at %s:%s\n", peer_id, address, port);
+    }
+    
+    if (packet.type == CDT_PACKET_ALLOC_REQ && host.manager == 1) { // only the manager can allocate a page
+      int peer_id;
+      if (cdt_packet_alloc_req_parse(&packet, &peer_id) != 0) {
+        fprintf(stderr, "Failed to parse allocation request packet from %s:%d\n", peer->connection.address, peer->connection.port);
+        break;
+      }
+
+      printf("Received allocation request from peer %d\n", peer_id);
     }
 
     // TODO: handle other packets

--- a/src/util.c
+++ b/src/util.c
@@ -1,0 +1,22 @@
+#include <arpa/inet.h>
+#include "util.h"
+
+uint64_t htonll(uint64_t x) {
+#if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+  return x;
+#elif __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+  return ((uint64_t)htonl(x & 0xFFFFFFFF) << 32) | htonl(x >> 32);
+#else
+#error "Byte order not supported"
+#endif
+}
+
+uint64_t ntohll(uint64_t x) {
+#if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+  return x;
+#elif __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+  return ((uint64_t)ntohl(x & 0xFFFFFFFF) << 32) | ntohl(x >> 32);
+#else
+#error "Byte order not supported"
+#endif
+}


### PR DESCRIPTION
Implement shared page allocation.
Case 1: cdt_malloc called by manager
- The main thread in the manager machine directly searches the manager pagetable and finds an unused PTE, acquires its lock, sets writer to the manager's ID (0), mallocs a local page, and returns the shared VA

Case 2: cdt_malloc called by non-manager machine A
- The main thread in A sends a request to the manager for a single page. 
- The manager's receiver thread A searches the manager pagetable, finds an unused PTE, acquires its lock, sets the writer to A's ID, and sends the shared VA to A
- A's receiver thread for the manager receives the shared VA packet and forwards it to the main thread in A using a message queue.

Notes: 
- If the manager loops over the pagetable once and doesn't find an unused PTE the allocation fails. If we implement freeing then we could continue searching until some timeout.
- PAGESIZE is fixed to 4096 and the number of shared pages was arbitrarily set to 1028
- shared_va's are fixed and should never be changed after initialization