### PR TITLE
Working thread creation and assignment

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,7 @@
       "request": "launch",
       "preLaunchTask": "make",
       "program": "${workspaceFolder}/bin/cli/coordinate",
-      "args": ["--host", "localhost:8000", "${workspaceFolder}/examples/test/bin/test"],
+      "args": ["--host", "localhost:8000", "--cores", "2", "${workspaceFolder}/examples/test/bin/test"],
       "stopAtEntry": false,
       "cwd": "${workspaceFolder}/src",
       "environment": [],

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ sudo make install
 ```
 To start the Coordinate manager with the user program ./example/test/bin/test
 ```
-coordinate --host <args> ./example/test/bin/test <user program args>
+coordinate --host <args> --cores <number of machines> ./example/test/bin/test <user program args>
 ```
 To connect a Coordinate peer with the user program ./example/test/bin/test
 ```

--- a/examples/test/main.c
+++ b/examples/test/main.c
@@ -1,8 +1,23 @@
 #include <stdio.h>
+#include <unistd.h>
 #include <coordinate.h>
+
+void* print_message(void* arg) {
+  printf("Hello from the second thread, my arg is %p\n", arg);
+  return NULL;
+}
 
 int main(int argc, char *argv[]) {
   cdt_init();
-  printf("Hello world\n");
+
+  printf("Hello from the main thread\n");
+  
+  cdt_thread_t thread;
+  cdt_thread_create(&thread, print_message, NULL);
+
+  cdt_thread_join(&thread, NULL);
+
+  sleep(5);
+
   return 0;
 }

--- a/include/packet.h
+++ b/include/packet.h
@@ -48,6 +48,8 @@ typedef struct cdt_packet_t {
   char data[CDT_PACKET_DATA_SIZE];
 } cdt_packet_t;
 
+uint32_t cdt_packet_response_get_requester(cdt_packet_t *packet);
+
 int cdt_packet_self_identify_create(cdt_packet_t *packet, const char *address, const char *port);
 void cdt_packet_self_identify_parse(cdt_packet_t *packet, char **address, char **port);
 
@@ -74,11 +76,11 @@ void cdt_packet_thread_create_req_parse(cdt_packet_t *packet, uint64_t *procedur
 void cdt_packet_thread_create_resp_create(cdt_packet_t *packet, cdt_thread_t *thread);
 void cdt_packet_thread_create_resp_parse(cdt_packet_t *packet, cdt_thread_t *thread);
 
-void cdt_packet_thread_assign_req_create(cdt_packet_t *packet, uint64_t procedure, uint64_t arg, uint32_t thread_id);
-void cdt_packet_thread_assign_req_parse(cdt_packet_t *packet, uint64_t *procedure, uint64_t *arg, uint32_t *thread_id);
+void cdt_packet_thread_assign_req_create(cdt_packet_t *packet, uint32_t parent_id, uint64_t procedure, uint64_t arg, uint32_t thread_id);
+void cdt_packet_thread_assign_req_parse(cdt_packet_t *packet, uint32_t *parent_id, uint64_t *procedure, uint64_t *arg, uint32_t *thread_id);
 
-void cdt_packet_thread_assign_resp_create(cdt_packet_t *packet, uint32_t status);
-void cdt_packet_thread_assign_resp_parse(cdt_packet_t *packet, uint32_t *status);
+void cdt_packet_thread_assign_resp_create(cdt_packet_t *packet, uint32_t requester_id, uint32_t status);
+void cdt_packet_thread_assign_resp_parse(cdt_packet_t *packet, uint32_t *requester_id, uint32_t *status);
 
 void cdt_packet_read_req_create(cdt_packet_t *packet, uint64_t page_addr);
 void cdt_packet_read_req_parse(cdt_packet_t *packet, uint64_t *page_addr);

--- a/include/worker.h
+++ b/include/worker.h
@@ -5,6 +5,8 @@
 
 typedef struct cdt_peer_t cdt_peer_t;
 typedef struct cdt_packet_t cdt_packet_t;
+typedef struct cdt_host_t cdt_host_t;
+typedef struct cdt_thread_t cdt_thread_t;
 
 /**
  * Start a worker thread for a peer.
@@ -17,5 +19,19 @@ void* cdt_worker_thread_start(void *arg);
  * Handle CDT_PACKET_THREAD_CREATE_REQ
  */
 int cdt_worker_thread_create(cdt_peer_t *sender, cdt_packet_t *packet);
+
+/**
+ * The underlying implementation of creating a thread.
+ * 
+ * host->thread_lock MUST be held before calling this
+ * 
+ * Returns NULL on failure, otherwise a pointer to the newly created thread.
+ */
+cdt_thread_t* cdt_worker_do_thread_create(cdt_host_t *host, cdt_peer_t *sender, cdt_packet_t *packet);
+
+/**
+ * Handle CDT_PACKET_THREAD_ASSIGN_REQ
+ */
+int cdt_worker_thread_assign(cdt_peer_t *sender, cdt_packet_t *packet);
 
 #endif

--- a/src/cli/main.c
+++ b/src/cli/main.c
@@ -19,7 +19,7 @@ int main(int argc, char *argv[]) {
   }
 
   if (argc < 2 || coordinate_argc == -1) {
-    fprintf(stderr, "Usage: %s --host IP:PORT [--connect IP:PORT] COMMAND [INITIAL_ARGS]...\n", argv[0]);
+    fprintf(stderr, "Usage: %s --host IP:PORT [--cores CORES --connect IP:PORT] COMMAND [COMMAND_ARGS]\n", argv[0]);
     return -1;
   }
 

--- a/src/cli/main.c
+++ b/src/cli/main.c
@@ -4,6 +4,7 @@
 #include <string.h>
 #include <errno.h>
 #include <sys/wait.h>
+#include <sys/personality.h>
 
 int main(int argc, char *argv[]) {
   int coordinate_argc = -1;
@@ -48,6 +49,13 @@ int main(int argc, char *argv[]) {
     if (putenv("LD_PRELOAD=libcoordinate.dsm.so") != 0) {
       fprintf(stderr, "%s: Failed to set LD_PRELOAD\n", argv[0]);
       return -1;
+    }
+
+    if (personality(ADDR_NO_RANDOMIZE) == -1) {
+      // Disable address space layout randomization so that functions will be located at the same
+      // addresses across the different machines. This is essential to allowing threads to be
+      // started on other machines using just a pointer to a function.
+      fprintf(stderr, "%s: Failed to disable address space layout randomization: %s\n", argv[0], strerror(errno));
     }
 
     execvp(argv[coordinate_argc], argv + coordinate_argc);
@@ -104,7 +112,7 @@ int main(int argc, char *argv[]) {
   int status;
   wait(&status);
   if (status != 0) {
-    fprintf(stderr, "%s: Failed to start user process\n", argv[0]);
+    fprintf(stderr, "%s: User process exited with status code %d\n", argv[0], status);
   }
 
   return status;

--- a/src/host.c
+++ b/src/host.c
@@ -138,7 +138,7 @@ void* cdt_host_thread(void *arg) {
     peer->connection = connection;
     cdt_peer_start(peer);
 
-    cdt_host.peers_to_be_connected &= ~peer->id;
+    cdt_host.peers_to_be_connected &= ~(1 << peer->id);
     cdt_host.num_peers++;
   }
 

--- a/src/worker.c
+++ b/src/worker.c
@@ -13,6 +13,9 @@ void* cdt_worker_thread_start(void *arg) {
     case CDT_PACKET_THREAD_CREATE_REQ:
       res = cdt_worker_thread_create(peer, &packet);
       break;
+    case CDT_PACKET_THREAD_ASSIGN_REQ:
+      res = cdt_worker_thread_assign(peer, &packet);
+      break;
     // more cases...
     default:
       debug_print("Unexpected packet type: %d\n", packet.type);
@@ -29,26 +32,49 @@ void* cdt_worker_thread_start(void *arg) {
 
 int cdt_worker_thread_create(cdt_peer_t *sender, cdt_packet_t *packet) {
   cdt_host_t *host = cdt_get_host();
-  if (!host) {
-    debug_print("Host not yet started\n");
-    return -1;
-  }
-
-  uint64_t procedure, arg;
-  cdt_packet_thread_create_req_parse(packet, &procedure, &arg);
+  if (!host) return -1;
 
   pthread_mutex_lock(&host->thread_lock);
 
+  cdt_thread_t *new_thread = cdt_worker_do_thread_create(host, sender, packet);
+
+  if (new_thread != NULL) {
+    host->thread_counter++;
+    cdt_packet_thread_create_resp_create(packet, new_thread);
+  } else {
+    cdt_thread_t invalid_thread = { .valid = 0 };
+    cdt_packet_thread_create_resp_create(packet, &invalid_thread);
+  }
+
+  pthread_mutex_unlock(&host->thread_lock);
+
+  if (new_thread == NULL) {
+    if (cdt_connection_send(&sender->connection, packet) != 0)
+      debug_print("Failed to send thread create response to peer %d\n", sender->id);
+
+    return -1;
+  }
+
+  if (cdt_connection_send(&sender->connection, packet) != 0) {
+    debug_print("Failed to send thread create response to peer %d\n", sender->id);
+    return -1;
+  }
+
+  return 0;
+}
+
+cdt_thread_t* cdt_worker_do_thread_create(cdt_host_t *host, cdt_peer_t *sender, cdt_packet_t *packet) {
+  uint64_t procedure, arg;
+  cdt_packet_thread_create_req_parse(packet, &procedure, &arg);
+
   if (host->num_threads >= host->num_peers) {
     debug_print("Maximum number of threads exceeded\n");
-    pthread_mutex_unlock(&host->thread_lock);
-    // TODO send response with failure
-    return -1;
+    return NULL;
   }
 
   cdt_peer_t *idle_peer = NULL;
 
-  for (uint32_t i = 0; i < CDT_MAX_MACHINES; i++) {
+  for (uint32_t i = 0; i < host->num_peers; i++) {
     cdt_peer_t *peer = host->peers + i;
     if (!peer->thread.valid) {
       idle_peer = peer;
@@ -58,39 +84,100 @@ int cdt_worker_thread_create(cdt_peer_t *sender, cdt_packet_t *packet) {
 
   if (idle_peer == NULL) {
     debug_print("No idle peers\n");
-    pthread_mutex_unlock(&host->thread_lock);
-    // TODO send response with failure
-    return -1;
+    return NULL;
   }
 
   idle_peer->thread.remote_peer_id = idle_peer->id;
   idle_peer->thread.remote_thread_id = host->thread_counter++;
 
-  cdt_packet_thread_assign_req_create(packet, procedure, arg, idle_peer->thread.remote_thread_id);
+  // TODO: handle case where idle_peer is the manager
+
+  cdt_packet_thread_assign_req_create(packet, sender->id, procedure, arg, idle_peer->thread.remote_thread_id);
 
   if (cdt_connection_send(&idle_peer->connection, packet) != 0) {
     debug_print("Failed to send thread assign request for thread %d to peer %d\n", idle_peer->thread.remote_thread_id, idle_peer->id);
-    pthread_mutex_unlock(&host->thread_lock);
-    return -1;
+    return NULL;
   }
 
-  if (mq_receive(sender->task_queue, (char*)packet, sizeof(*packet), NULL) == -1) {
-    pthread_mutex_unlock(&host->thread_lock);
-    return -1;
-  }
+  if (mq_receive(sender->task_queue, (char*)packet, sizeof(*packet), NULL) == -1)
+    return NULL;
 
-  uint32_t status;
-  cdt_packet_thread_assign_resp_parse(packet, &status);
+  uint32_t requester, status;
+  cdt_packet_thread_assign_resp_parse(packet, &requester, &status);
 
   if (status != 0) {
     debug_print("Failed to assign thread to peer %d\n", idle_peer->id);
-    pthread_mutex_unlock(&host->thread_lock);
-    return -1;
+    return NULL;
   }
 
   idle_peer->thread.valid = 1;
 
+  return &idle_peer->thread;
+}
+
+int cdt_worker_thread_assign(cdt_peer_t *sender, cdt_packet_t *packet) {
+  cdt_host_t *host = cdt_get_host();
+  if (!host) return -1;
+
+  uint32_t parent_id, thread_id;
+  uint64_t procedure, arg;
+  cdt_packet_thread_assign_req_parse(packet, &parent_id, &procedure, &arg, &thread_id);
+
+  if (sender->id != 0) { // sender must be manager
+    cdt_packet_thread_assign_resp_create(packet, parent_id, 1);
+
+    if (cdt_connection_send(&sender->connection, packet)) {
+      debug_print("Failed to reject thread assign request from non-manager\n");
+      return -1;
+    }
+
+    return 0;
+  }
+
+  pthread_mutex_lock(&host->thread_lock);
+
+  cdt_peer_t *self = &host->peers[host->self_id];
+  if (self->thread.valid) {
+    pthread_mutex_unlock(&host->thread_lock);
+    
+    cdt_packet_thread_assign_resp_create(packet, parent_id, 1);
+
+    if (cdt_connection_send(&sender->connection, packet)) {
+      debug_print("Failed to reject thread assign request because of already running thread\n");
+      return -1;
+    }
+
+    return 0;
+  }
+
+  self->thread.remote_peer_id = host->self_id;
+  self->thread.remote_thread_id = thread_id;
+  self->thread.valid = 1;
+
+  if (pthread_create(&self->thread.local_id, NULL, (void*(*)(void*))procedure, (void*)arg) != 0) {
+    self->thread.valid = 0;
+    pthread_mutex_unlock(&host->thread_lock);
+
+    debug_print("Failed to start thread for procedure %p and arg %p\n", (void*)procedure, (void*)arg);
+
+    cdt_packet_thread_assign_resp_create(packet, parent_id, 1);
+
+    if (cdt_connection_send(&sender->connection, packet)) {
+      debug_print("Failed to reject thread assign request\n");
+      return -1;
+    }
+
+    return 0;
+  }
+
   pthread_mutex_unlock(&host->thread_lock);
+
+  cdt_packet_thread_assign_resp_create(packet, parent_id, 0);
+
+  if (cdt_connection_send(&sender->connection, packet)) {
+    debug_print("Failed to send thread assignment confirmation\n");
+    return -1;
+  }
 
   return 0;
 }


### PR DESCRIPTION
`cdt_thread_create` called from user code now correctly causes the manager to find an idle machine, assign the thread to it, and have that machine start executing the thread.

I also added the `--cores` option to the cli, which causes the manager to begin executing user code after that number of machines are connected to the network.